### PR TITLE
MapAnything v1.1 Update

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -34,6 +34,7 @@ Model:
   Pointcloud_Save:
     sample_ratio: 0.015
     conf_threshold_coef: 0.75 # conf_threshold = np.mean(confs) * conf_threshold_coef
+    use_confidence_filtering: true # enable/disable pc filtering using pred['conf'] - globally
 
 Loop:
   DBoW:

--- a/configs/map_long_config.yaml
+++ b/configs/map_long_config.yaml
@@ -1,0 +1,28 @@
+inherit_from: "configs/base_config.yaml"
+
+Weights:
+  model: 'Mapanything'  # Use MapAnything foundation model
+  # Map: './weights/map_anything'  # Path to MapAnything weights
+  Map: 'facebook/map_anything'    # Other options: 'facebook/map-anything-apache' or 'facebook/map-anything-v1' or 'facebook/map-anything-apache-v1'
+
+Model:
+  chunk_size: 150
+  overlap: 100
+  loop_chunk_size: 20 # imgs of loop chunk = 2 * loop_chunk_size
+  loop_enable: True
+  useDBoW: False
+  delete_temp_files: True
+  align_method: 'numba' # 'numba' or 'numpy', use 'numba' would be faster
+  using_sim3: False # Using SIM(3) alignment if True, while using SE(3) alignment if False,mapanything need se3
+  reference_frame_mid: False
+  # If reference_frame_mid == True, use the middle frame within the chunk as the
+  # reference frame to alleviate the scale drift when loop closure is not available.
+  # Disable it for now cuz i found some bugs related to this feature [by deng on 09 Oct].
+  calib: False # only mapanything; get k from kitti for input
+  h: 720 # input h
+  w: 1280 # input w
+
+Pointcloud_Save:
+    sample_ratio: 1.0     # Downsample ratio for final point cloud - TODO: Check if ok.
+    conf_threshold_coef: 0.75 # Confidence threshold coefficient
+    use_confidence_filtering: false # Disable for MapAnything v2. Can set to True for v1.

--- a/configs/map_long_config.yaml
+++ b/configs/map_long_config.yaml
@@ -3,7 +3,7 @@ inherit_from: "configs/base_config.yaml"
 Weights:
   model: 'Mapanything'  # Use MapAnything foundation model
   # Map: './weights/map_anything'  # Path to MapAnything weights
-  Map: 'facebook/map_anything'    # Other options: 'facebook/map-anything-apache' or 'facebook/map-anything-v1' or 'facebook/map-anything-apache-v1'
+  Map: 'facebook/map-anything-v1'    # Other options: 'facebook/map-anything-apache' or 'facebook/map-anything-v1' or 'facebook/map-anything-apache-v1'
 
 Model:
   chunk_size: 150
@@ -22,7 +22,7 @@ Model:
   h: 720 # input h
   w: 1280 # input w
 
-Pointcloud_Save:
+  Pointcloud_Save:
     sample_ratio: 1.0     # Downsample ratio for final point cloud - TODO: Check if ok.
     conf_threshold_coef: 0.75 # Confidence threshold coefficient
-    use_confidence_filtering: false # Disable for MapAnything v2. Can set to True for v1.
+    use_conf_filter: True # Disable for MapAnything v2. Can set to True for v1.

--- a/vggt_long.py
+++ b/vggt_long.py
@@ -283,7 +283,7 @@ class VGGT_Long:
                 mask2 = chunk_data2["mask"][:self.overlap]
                 mask = mask1.squeeze() & mask2.squeeze()
 
-            if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True):
+            if self.config['Model']['Pointcloud_Save'].get('use_conf_filter', True):
                 conf_threshold = min(np.median(conf1), np.median(conf2)) * 0.1
             else:
                 conf_threshold = -1.0
@@ -321,7 +321,7 @@ class VGGT_Long:
                 point_map_a = chunk_data_a['world_points'][chunk_a_rela_begin:chunk_a_rela_end]
                 conf_a = chunk_data_a['world_points_conf'][chunk_a_rela_begin:chunk_a_rela_end]
 
-                if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True):
+                if self.config['Model']['Pointcloud_Save'].get('use_conf_filter', True):
                     conf_threshold = min(np.median(conf_a), np.median(conf_loop)) * 0.1
                 else:
                     conf_threshold = -1.0
@@ -354,7 +354,7 @@ class VGGT_Long:
                 point_map_b = chunk_data_b['world_points'][chunk_b_rela_begin:chunk_b_rela_end]
                 conf_b = chunk_data_b['world_points_conf'][chunk_b_rela_begin:chunk_b_rela_end]
 
-                if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True):
+                if self.config['Model']['Pointcloud_Save'].get('use_conf_filter', True):
                     conf_threshold = min(np.median(conf_b), np.median(conf_loop)) * 0.1
                 else:
                     conf_threshold = -1.0
@@ -446,7 +446,7 @@ class VGGT_Long:
                     confs=confs_first,  # shape: (H, W)
                     output_path=ply_path_first,
                     conf_threshold=(np.mean(confs_first) * self.config['Model']['Pointcloud_Save']['conf_threshold_coef']
-                        if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True) else -1.0),
+                        if self.config['Model']['Pointcloud_Save'].get('use_conf_filter', True) else -1.0),
                     sample_ratio=self.config['Model']['Pointcloud_Save']['sample_ratio']
                 )
 
@@ -464,7 +464,7 @@ class VGGT_Long:
                 confs=confs,  # shape: (H, W)
                 output_path=ply_path,
                 conf_threshold=(np.mean(confs) * self.config['Model']['Pointcloud_Save']['conf_threshold_coef']
-                    if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True) else -1.0),
+                    if self.config['Model']['Pointcloud_Save'].get('use_conf_filter', True) else -1.0),
                 sample_ratio=self.config['Model']['Pointcloud_Save']['sample_ratio']
             )
 

--- a/vggt_long.py
+++ b/vggt_long.py
@@ -99,7 +99,6 @@ class VGGT_Long:
 
         self.chunk_size = self.config['Model']['chunk_size']
         self.overlap = self.config['Model']['overlap']
-        self.conf_threshold = 1.5
         self.seed = 42
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.dtype = torch.bfloat16 if torch.cuda.get_device_capability()[0] >= 8 else torch.float16
@@ -284,7 +283,10 @@ class VGGT_Long:
                 mask2 = chunk_data2["mask"][:self.overlap]
                 mask = mask1.squeeze() & mask2.squeeze()
 
-            conf_threshold = min(np.median(conf1), np.median(conf2)) * 0.1
+            if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True):
+                conf_threshold = min(np.median(conf1), np.median(conf2)) * 0.1
+            else:
+                conf_threshold = -1.0
             s, R, t = weighted_align_point_maps(point_map1, 
                                                 conf1, 
                                                 point_map2, 
@@ -318,8 +320,11 @@ class VGGT_Long:
                 
                 point_map_a = chunk_data_a['world_points'][chunk_a_rela_begin:chunk_a_rela_end]
                 conf_a = chunk_data_a['world_points_conf'][chunk_a_rela_begin:chunk_a_rela_end]
-            
-                conf_threshold = min(np.median(conf_a), np.median(conf_loop)) * 0.1
+
+                if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True):
+                    conf_threshold = min(np.median(conf_a), np.median(conf_loop)) * 0.1
+                else:
+                    conf_threshold = -1.0
                 mask = None
                 if item[1]['mask'] is not None:
                     mask_loop = item[1]['mask'][:chunk_a_range[1] - chunk_a_range[0]]
@@ -348,8 +353,11 @@ class VGGT_Long:
                 
                 point_map_b = chunk_data_b['world_points'][chunk_b_rela_begin:chunk_b_rela_end]
                 conf_b = chunk_data_b['world_points_conf'][chunk_b_rela_begin:chunk_b_rela_end]
-            
-                conf_threshold = min(np.median(conf_b), np.median(conf_loop)) * 0.1
+
+                if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True):
+                    conf_threshold = min(np.median(conf_b), np.median(conf_loop)) * 0.1
+                else:
+                    conf_threshold = -1.0
                 mask = None
                 if item[1]['mask'] is not None:
                     mask_loop = item[1]['mask'][-chunk_b_range[1] + chunk_b_range[0]:]
@@ -437,8 +445,8 @@ class VGGT_Long:
                     colors=colors_first,  # shape: (H, W, 3)
                     confs=confs_first,  # shape: (H, W)
                     output_path=ply_path_first,
-                    conf_threshold=np.mean(confs_first) * self.config['Model']['Pointcloud_Save'][
-                        'conf_threshold_coef'],
+                    conf_threshold=(np.mean(confs_first) * self.config['Model']['Pointcloud_Save']['conf_threshold_coef']
+                        if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True) else -1.0),
                     sample_ratio=self.config['Model']['Pointcloud_Save']['sample_ratio']
                 )
 
@@ -455,7 +463,8 @@ class VGGT_Long:
                 colors=colors,  # shape: (H, W, 3)
                 confs=confs,  # shape: (H, W)
                 output_path=ply_path,
-                conf_threshold=np.mean(confs) * self.config['Model']['Pointcloud_Save']['conf_threshold_coef'],
+                conf_threshold=(np.mean(confs) * self.config['Model']['Pointcloud_Save']['conf_threshold_coef']
+                    if self.config['Model']['Pointcloud_Save'].get('use_confidence_filtering', True) else -1.0),
                 sample_ratio=self.config['Model']['Pointcloud_Save']['sample_ratio']
             )
 


### PR DESCRIPTION
With the release of [new and improved checkpoints](https://github.com/Nik-V9) for MapAnything - the performance of the model is indeed much better than v1, but it the confidence values in the output (`pred['conf']`) cannot be used as before. 
This PR makes some simple changes to allow VGGT-Long users to toggle this via the config. These changes have been tested thoroughly by running `vggt-long.py` using the `map_long_config.yaml` configuration and inspecting the final pointcloud files. Please review and merge if it looks ok; my hope is to save time for others who are trying to run VGGT-Long with the MapAnything config for their projects :)